### PR TITLE
ci(workflow): :art: refactor reusable workflows for 'datajoint_workflow'

### DIFF
--- a/.github/workflows/mkdocs-build.yml
+++ b/.github/workflows/mkdocs-build.yml
@@ -17,10 +17,14 @@ on:
         required: false
         type: string
         default: "3.9"
+      release_branch:
+        description: "The originating branch that is allowed to trigger the docs build process"
+        default: main
+        type: string
+        required: false
 
 jobs:
   get_last_pushed_tag:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout repository
@@ -28,13 +32,16 @@ jobs:
         uses: actions/checkout@v3
       - run: |
           git fetch --prune --unshallow
-          echo "LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null)"" >> $GITHUB_ENV
+          echo "LAST_TAG="$(git describe --tags --abbrev=0 2>/dev/null)"" >>$GITHUB_ENV
     outputs:
       tag: ${{ env.LAST_TAG }}
 
   build_gh_pages:
     needs: [get_last_pushed_tag]
-    if: always() && needs.get_last_pushed_tag.result == 'success'
+    if: |
+      always() &&
+      (needs.get_last_pushed_tag.result == 'success') &&
+      (github.ref_name == '${{inputs.release_branch}}')
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout repository
@@ -49,8 +56,8 @@ jobs:
 
           if [[ -z ${branch_exists} ]]; then
             echo "Creating the branch '${{ inputs.branch_name }}'"
-            git config --global user.email "github-actions[bot]@users.noreply.github.com"
-            git config --global user.name "github-actions[bot]"
+            git config --local user.email "github-actions[bot]@users.noreply.github.com"
+            git config --local user.name "github-actions[bot]"
             git checkout --orphan ${{ inputs.branch_name }}
             git reset --hard
             git commit --allow-empty -m "ci(bot): initializing branch"
@@ -93,4 +100,5 @@ jobs:
           pip install nox
 
       - name: 📖  Build docs and deploy to gh-pages
+        id: mkdocs-build-nox
         run: nox --non-interactive -v -s docs -- --version ${{ inputs.new_tag }} ${{ env.DOCS_ARG }}

--- a/.github/workflows/semantic-versioning.yml
+++ b/.github/workflows/semantic-versioning.yml
@@ -3,19 +3,19 @@ name: semantic-versioning
 on:
   workflow_call:
     inputs:
-      py_ver:
-        description: "which python version to use, e.g., '3.9'"
-        required: false
-        type: string
-        default: "3.9"
       create_release:
-        description: "Create a new release"
+        description: "Set to 'false' to always skip creating a new tag and release"
         default: true
         type: boolean
         required: false
-      release_only:
-        description: "List of single-quoted, comma separated values of release types, e.g., ['major','minor']"
-        default: "['major','minor','patch']"
+      release_types:
+        description: "List of single-quoted, comma separated values of release type names to be considered for release, e.g., major,minor,patch"
+        default: major,minor,patch
+        type: string
+        required: false
+      release_branch:
+        description: "The originating branch that is allowed to trigger pushing version changes and creating releases. Otherwise, only version information is collected."
+        default: main
         type: string
         required: false
 
@@ -61,6 +61,8 @@ jobs:
       - name: 🛎️  Checkout repository
         id: check-repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - id: set-datetime
         run: echo "::set-output name=datetime::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
@@ -75,60 +77,99 @@ jobs:
         uses: mathieudutour/github-tag-action@v6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          release_branches: master,main
-          pre_release_branches: develop
+          release_branches: ${{ inputs.release_branch }}
+          pre_release_branches: develop,dev,wip
           fetch_all_tags: true
           dry_run: true
+          default_bump: false
+          custom_release_rules: force_bump_patch:patch,force_bump_minor:minor,force_bump_major:major
+
+      - id: correct-no-version
+        run: |
+          echo "::set-output name=bumped::false"
+          if [ -z "${{ steps.semver_tag.outputs.new_tag }}" ]; then
+            echo "::set-output name=new_tag::${{ steps.semver_tag.outputs.previous_tag }}"
+            echo "::set-output name=new_version::${{ steps.semver_tag.outputs.previous_version }}"
+          else
+            echo "::set-output name=new_tag::${{ steps.semver_tag.outputs.new_tag }}"
+            echo "::set-output name=new_version::${{ steps.semver_tag.outputs.new_version }}"
+            [[ "${{ steps.semver_tag.outputs.new_tag }}"="${{ steps.semver_tag.outputs.previous_tag }}" ]] || echo "::set-output name=bumped::true"
+          fi
+          RELEASE_ONLY="['$(echo "${{ inputs.release_types }}" | sed "s/\\,/\\','/g" | sed 's/ //g')']"
+          echo "::set-output name=release_array::${RELEASE_ONLY}"
+        shell: bash
 
     outputs:
-      new_tag: ${{ steps.semver_tag.outputs.new_tag }}
-      new_version: ${{ steps.semver_tag.outputs.new_version }}
+      new_tag: ${{ steps.correct-no-version.outputs.new_tag }}
+      new_version: ${{ steps.correct-no-version.outputs.new_version }}
       previous_tag: ${{ steps.semver_tag.outputs.previous_tag }}
       previous_version: ${{ steps.semver_tag.outputs.previous_version }}
       release_type: ${{ steps.semver_tag.outputs.release_type }}
       changelog: ${{ steps.semver_tag.outputs.changelog }}
-      repo_lower: ${{ steps.semver_tag.outputs.repo_lower }}
-      datetime: ${{ steps.semver_tag.outputs.datetime }}
+      repo_lower: ${{ steps.set-repo-lower.outputs.repo_lower }}
+      datetime: ${{ steps.set-datetime.outputs.datetime }}
+      release_array: ${{ steps.correct-no-version.outputs.release_array }}
+      bumped: ${{ steps.correct-no-version.outputs.bumped }}
 
-  push_version_file:
+  update_version_files:
     needs: get_version
-    if: always() && needs.get_version.result == 'success'
+    if: |
+      always() &&
+      (github.ref_name == '${{ inputs.release_branch }}') &&
+      (needs.get_version.result == 'success') &&
+      (needs.get_version.bumped == 'true' || needs.get_version.outputs.new_version == '0.0.0')
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout repository
         id: check-repo
         uses: actions/checkout@v3
 
-      - name: 🐍  Use Python
-        id: use-python
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ inputs.py_ver }}
-
-      - name: 🐍  Install Nox
-        id: install-nox
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          pip install nox
-
       - name: 🐍  Bump python package version
+        id: update-version-dot-py
         run: |
-          nox --non-interactive -v -s write_version -- --pversion ${{ needs.get_version.outputs.previous_version }} --version ${{ needs.get_version.outputs.new_version }}
+          PKG_VERSION_FILE=src/*/version.py
+          PREV_PKG_VER=$(grep -Eo "(\"|').*(\"|')$" $PKG_VERSION_FILE | cut -d '"' -f 2 | cut -d "'" -f 2)
+          echo -e "PKG_VERSION_FILE=$PKG_VERSION_FILE\nPREV_PKG_VER=$PREV_PKG_VER"
+          [[ -z $PREV_PKG_VER ]] && exit 1
+          echo -e "__version__ = \"${{ needs.get_version.outputs.new_version }}\"" > $PKG_VERSION_FILE
+        shell: bash
+
+      - name: 📜  Update changelog
+        id: update-changelog
+        run: |
+          echo -e "changelog=\n${{ needs.get_version.outputs.changelog }}"
+          [[ -z "${{ needs.get_version.outputs.changelog }}" ]] && exit 0
+          [[ ! -f CHANGELOG.md ]] && exit 0
+          NEWSEC_STR="## \`${{ needs.get_version.outputs.new_tag }}\`"
+          CHANGELOG_STR=$(sed '1d' <<< "${{ needs.get_version.outputs.changelog }}")
+          echo -e "NEWSEC_STR=${NEWSEC_STR}\nCHANGELOG_STR=\n${CHANGELOG_STR}"
+          [[ -z "${CHANGELOG_STR}" ]] && exit 0
+          sed -i '/Changelog/r'<(printf "\n%s\n%s\n\n" "$NEWSEC_STR" "$CHANGELOG_STR") CHANGELOG.md
+        shell: bash
+
+      - name: 📌  Push changes
+        id: push-ver-changes
+        run: |
+          echo -e "Committing and pushing:\n$(git status --porcelain)"
           if [ -z "$(git status --porcelain)" ]; then
-            echo "No change in existing 'version.py' file."
+            echo "No versioning file changes."
             exit 0
           fi
-          echo -e "::debug::Committing and pushing:\n$(git status --porcelain)"
-          git commit -m "ci(versioning): write ver ${{ needs.get_version.outputs.new_version }} to 'version.py'"
-          git push origin HEAD:main
-
-    outputs:
-      python-version: ${{ steps.use-python.outputs.python-version }}
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add .
+          git commit -m "chore(semver): update files with new version information"
+          git push origin HEAD:${{ inputs.release_branch }}
+        shell: bash
 
   create_tag_and_release:
-    needs: [push_version_file, get_version]
-    if: always() && needs.push_version_file.result == 'success'
+    needs: [get_version, update_version_files]
+    if: |
+      always() &&
+      (needs.get_version.result == 'success') &&
+      (needs.update_version_files.result == 'success') &&
+      (inputs.create_release == 'true') &&
+      (github.ref_name == '${{ inputs.release_branch }}')
     runs-on: ubuntu-latest
     steps:
       - name: 🛎️  Checkout repository
@@ -141,18 +182,17 @@ jobs:
         id: push-new-tag
         shell: bash
         run: |
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          git config --global user.name "github-actions[bot]"
-          git tag -a ${{ needs.get_version.outputs.new_tag }} --force -m "ci(versioning): tagging ${{ needs.get_version.outputs.new_tag }}:${{ inputs.release_type }}"
-          git push origin --tags
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git tag -a ${{ needs.get_version.outputs.new_tag }} --force -m "chore(semver): tagging ${{ needs.get_version.outputs.new_tag }}:${{ inputs.release_type }}"
+          git push -f origin ${{ needs.get_version.outputs.new_tag }}
 
       - name: 📦  Create a new release from semver tag
         id: release-version
         if: |
           always() &&
-          (inputs.create_release == 'true') &&
           (!contains('pre', ${{ needs.get_version.outputs.release_type }})) &&
-          (contains(fromJSON(${{ inputs.release_only }}), ${{ needs.get_version.outputs.release_type }}))
+          (contains(fromJSON(${{ needs.get_version.outputs.release_array }}), ${{ needs.get_version.outputs.release_type }}))
         uses: ncipollo/release-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -166,10 +206,3 @@ jobs:
       id: ${{ steps.release-version.outputs.id }}
       html_url: ${{ steps.release-version.outputs.html_url }}
       upload_url: ${{ steps.release-version.outputs.upload_url }}
-
-  if_run_tests_failed:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          echo "The 'run-tests' workflow failed or did not run. Skipping 'semantic-versioning' workflow."


### PR DESCRIPTION
- use bash instead of python for simple tasks
- special commit message to force bump version
- changelog updating
- better handling for how a tag and release is triggered